### PR TITLE
Added support for discarding events over the delay threshold

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,9 +5,14 @@ delay interval and unit. Incoming GeoEvents are added to a queue and held in mem
 elapsed, after which they are processed asynchronously in the GeoEvent service.
 
 This type of processor can be useful where administrators want to support streaming location data to users but 
-do not want to support near real-time updates.
+do not want to support near real-time updates.  Or when your data is delivered in a batch of records and you need to enforce temporal order.
 
 ![Example](geoevent-delay-processor.png?raw=true)
+
+<p> Examples:
+<p><b>Time Field = RECEIVED_TIME, Allow Duplicates = Yes, Use TRACK_ID = No</b><br>These settings will simply delay every event by the delay time.
+<p><b>Time Field = TIME_START, Allow Duplicates = No, Use TRACK_ID = No</b><br>These settings will use the TIME_START value to determine if an event has already been received with the same start time value. If an event has an identical value for TIME_START to a previous event, the current event will be dropped.
+<p><b>Time Field = TIME_START, Allow Duplicates = No, Use TRACK_ID = Yes</b><br>These settings will use the TRACK_ID and the TIME_START values to determine if an event has already been received with those same values. If an event has identical values for both TRACK_ID and TIME_START to a previous event, the current event will be dropped.
 
 ## Features
 * GeoEvent Delay Processor
@@ -41,5 +46,8 @@ Esri welcomes contributions from anyone and everyone. Please see our [guidelines
   * `Delay Value` Specifies a constant value by which GeoEvents will be delayed before further processing.
    Delayed events are added to queue and held in memory.
   * `Delay Value Unit` specifies the time unit for the delay value.
+  * `Delay Time Field` Choose the field that the delay time will be added to (RECEIVE_TIME, TIME_START, or TIME_END).
+  * `Allow Duplicates?` Should new events with the same timestamp as an event already in the queue be allowed to be added to the queue? If duplicates are allowed, multiple events with the same timestamp may enter the queue.
+  * `Use TRACK_ID` Should each unique TRACK_ID get its own queue, or should all events be stored in a single queue.
 
 

--- a/pom.xml
+++ b/pom.xml
@@ -1,14 +1,20 @@
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
 	<modelVersion>4.0.0</modelVersion>
-	<groupId>com.esri.geoevent.processor.delay</groupId>
-	<version>1.0</version>
+  <groupId>com.esri.geoevent.processor</groupId>
+  <version>10.4.0</version>
 	<packaging>bundle</packaging>
-	<artifactId>geoevent-delay-processor</artifactId>
-	<name>geoevent-delay-processor</name>
-
+  <artifactId>delay-processor</artifactId>
+  <name>Esri :: GeoEvent :: Processor :: Delay</name>
+  <description>Release ${project.release}: Delays the processing of events by a specified amount of time. All delayed events are held in a sorted queue in memory. The queue is sorted by event time (based on the time field selected). &lt;p&gt;&lt;b&gt;To clear the GeoEvent queue&lt;/b&gt; Restart the service.&lt;p&gt;&lt;b&gt;To clear the duplicate key cache&lt;/b&gt; change any one of Updates Allowed, Use TRACK_ID, or Delay Time Field and save your changes (then change it back if you like). &lt;p&gt;Examples:&lt;p&gt;&lt;b&gt;Time Field = RECEIVED_TIME, Allow Duplicates = Yes, Use TRACK_ID = No&lt;/b&gt;&lt;br&gt;These settings will simply delay every event by the delay time.&lt;p&gt;&lt;b&gt;Time Field = TIME_START, Allow Duplicates = No, Use TRACK_ID = No&lt;/b&gt;&lt;br&gt;These settings will use the TIME_START value to determine if an event has already been received with the same start time value. If an event has an identical value for TIME_START to a previous event, the current event will be dropped.&lt;p&gt;&lt;b&gt;Time Field = TIME_START, Allow Duplicates = No, Use TRACK_ID = Yes&lt;/b&gt;&lt;br&gt;These settings will use the TRACK_ID and the TIME_START values to determine if an event has already been received with those same values. If an event has identical values for both TRACK_ID and TIME_START to a previous event, the current event will be dropped.</description>
+  <url>http://www.esri.com</url>
 	<properties>
+    <project.release>1.3</project.release>
+    <maven.bundle.plugin.version>4.2.1</maven.bundle.plugin.version>
+    <maven.compiler.plugin.version>3.8.1</maven.compiler.plugin.version>
+    <junit.version>4.8.1</junit.version>
+    <contact.address>eironside@esri.com</contact.address>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-		<arcgis.version>10.6.1</arcgis.version>
 	</properties>
 
 	<dependencies>
@@ -16,25 +22,37 @@
 		<dependency>
 			<groupId>com.esri.geoevent.sdk</groupId>
 			<artifactId>geoevent-sdk</artifactId>
-			<version>${arcgis.version}</version>
+      <version>${project.version}</version>
 		</dependency>
 
 		<dependency>
 			<groupId>junit</groupId>
 			<artifactId>junit</artifactId>
-			<version>4.8.1</version>
+      <version>${junit.version}</version>
 			<scope>test</scope>
 		</dependency>
 
 	</dependencies>
 	<build>
+    <resources>
+      <resource>
+        <directory>src/main/resources</directory>
+        <filtering>true</filtering>
+      </resource>
+    </resources>
 		<pluginManagement>
 
 			<plugins>
 				<plugin>
+          <groupId>org.apache.felix</groupId>
+          <artifactId>maven-bundle-plugin</artifactId>
+          <version>${maven.bundle.plugin.version}</version>
+          <extensions>true</extensions>
+        </plugin>
+        <plugin>
 					<groupId>org.apache.maven.plugins</groupId>
 					<artifactId>maven-compiler-plugin</artifactId>
-					<version>3.3</version>
+          <version>${maven.compiler.plugin.version}</version>
 					<configuration>
 						<source>1.8</source>
 						<target>1.8</target>
@@ -47,17 +65,15 @@
 			<plugin>
 				<groupId>org.apache.felix</groupId>
 				<artifactId>maven-bundle-plugin</artifactId>
-				<version>4.2.1</version>
 				<extensions>true</extensions>
 				<configuration>
 					<instructions>
-						<!--<Build-Number></Build-Number>-->
 						<Bundle-SymbolicName>${project.groupId}.${project.artifactId}</Bundle-SymbolicName>
-						<Bundle-ContactAddress>mshareghi@esri.com</Bundle-ContactAddress>
-						<Bundle-Name>Delay Processor</Bundle-Name>
+            <Bundle-ContactAddress>${contact.address}</Bundle-ContactAddress>
+            <Bundle-Name>${project.artifactId}</Bundle-Name>
 						<Bundle-Version>${project.version}</Bundle-Version>
-						<AGES-Domain>com.esri.geoevent.processor</AGES-Domain>
-						<Export-Package/>
+            <AGES-Domain>${project.domain}</AGES-Domain>
+            <Export-Package />
 						<Private-Package>com.esri.geoevent.processor.delay</Private-Package>
 					</instructions>
 				</configuration>

--- a/src/main/java/com/esri/geoevent/processor/delay/DelayProcessor.java
+++ b/src/main/java/com/esri/geoevent/processor/delay/DelayProcessor.java
@@ -1,53 +1,91 @@
 package com.esri.geoevent.processor.delay;
 
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Observable;
+import java.util.concurrent.BlockingQueue;
+import java.util.concurrent.DelayQueue;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
+
 import com.esri.ges.core.component.ComponentException;
 import com.esri.ges.core.geoevent.GeoEvent;
 import com.esri.ges.core.geoevent.GeoEventPropertyName;
+import com.esri.ges.core.property.Property;
+import com.esri.ges.core.validation.ValidationException;
 import com.esri.ges.framework.i18n.BundleLogger;
 import com.esri.ges.framework.i18n.BundleLoggerFactory;
-import com.esri.ges.messaging.*;
+import com.esri.ges.messaging.EventDestination;
+import com.esri.ges.messaging.EventUpdatable;
+import com.esri.ges.messaging.GeoEventProducer;
+import com.esri.ges.messaging.Messaging;
+import com.esri.ges.messaging.MessagingException;
 import com.esri.ges.processor.GeoEventProcessorBase;
 import com.esri.ges.processor.GeoEventProcessorDefinition;
-
-import java.util.ArrayList;
-import java.util.Collections;
-import java.util.List;
-import java.util.Observable;
-import java.util.concurrent.*;
 
 /**
  * The DelayProcessor class processes incoming GeoEvents and delaying their execution by a specified time. Delayed
  * events are placed in a private queue and processed based on a combination of the delay time and the time they were
  * received by GeoEvent Server (the RECEIVED_TIME property).
  */
-public class DelayProcessor extends GeoEventProcessorBase
-    implements GeoEventProducer, EventUpdatable
+public class DelayProcessor extends GeoEventProcessorBase implements GeoEventProducer, EventUpdatable, DelayProperties
 {
     private static final BundleLogger LOGGER = BundleLoggerFactory.getLogger(DelayProcessor.class);
+  private static final int                     MAX_ENTRIES            = 20000;
 
-    private final ExecutorService executorService =  Executors.newSingleThreadExecutor();
-    private final BlockingQueue<DelayedGeoEvent> geoEventQueue = new DelayQueue<>();
+  private ExecutorService                      executorService        = Executors.newSingleThreadExecutor();
+  private final BlockingQueue<DelayedGeoEvent> geoEventQueue          = new DelayQueue<DelayedGeoEvent>();
 
-    private Messaging messaging;
+  private final Map<String, String>            geoEventTimeKeySet     = Collections.synchronizedMap(new LinkedHashMap<String, String>()
+                                                                        {
+                                                                          private static final long serialVersionUID = 3497816525702669924L;
+
+                                                                          protected boolean removeEldestEntry(Map.Entry<String, String> eldest)
+                                                                          {
+                                                                            return size() > MAX_ENTRIES;
+                                                                          }
+                                                                        });
+
+  private final Map<String, String>            geoEventLocationKeySet = Collections.synchronizedMap(new LinkedHashMap<String, String>()
+                                                                        {
+                                                                          private static final long serialVersionUID = 3497816525702669925L;
+
+                                                                          protected boolean removeEldestEntry(Map.Entry<String, String> eldest)
+                                                                          {
+                                                                            return size() > MAX_ENTRIES;
+                                                                          }
+                                                                        });
+
+  private final Messaging                      messaging;
     private GeoEventProducer geoEventProducer;
     private long delayValue;
     private TimeUnit delayValueUnit;
+  private long                                 delayMilliseconds      = 0;
+
+  private String                               delayField             = RECEIVED_TIME;
+  private boolean                              enforceDelayThreshold  = false;
+  private boolean                              allowDuplicates        = true;
+  private boolean                              useTrackID             = false;
+  private boolean                              useLocation            = false;
+
     private Future<?> eventLoop;
 
-    public DelayProcessor(GeoEventProcessorDefinition definition) throws ComponentException {
+  public DelayProcessor(GeoEventProcessorDefinition definition, Messaging messaging) throws ComponentException
+  {
         super(definition);
-    }
-
-    @Override
-    public void shutdown() {
-        executorService.shutdownNow();
-        super.shutdown();
+    this.messaging = messaging;
     }
 
     @Override
     public void setId(String id)
     {
         super.setId(id);
+    LOGGER.trace("Set delay processor ID: {0}", id);
         geoEventProducer = messaging.createGeoEventProducer(new EventDestination(id + ":event"));
     }
 
@@ -55,19 +93,37 @@ public class DelayProcessor extends GeoEventProcessorBase
     @Override
     public GeoEvent process(GeoEvent geoEvent) throws Exception
     {
-        if(geoEvent != null)
+    LOGGER.trace("Processing event with Delay Field={0}, Allow Duplicates={1}, Use TRACK_ID={2}, Use Location={3}, Enforece Delay Threshold={4}, Delay(ms)={5}: {6}", delayField, allowDuplicates, useTrackID, useLocation, enforceDelayThreshold, delayMilliseconds, geoEvent);
+
+    if (geoEvent != null)
+    {
+      final DelayedGeoEvent delayedGeoEvent = new DelayedGeoEvent(geoEvent, delayMilliseconds, delayField, useTrackID);
+      long eventDelay = delayedGeoEvent.getDelay(TimeUnit.SECONDS);
+      if (enforceDelayThreshold && eventDelay <= 0)
+      {
+        LOGGER.debug("Discarding expired GeoEvent (delay of {1} is already expired): {0}", geoEvent, eventDelay);
+      }
+      else
         {
-            long delayMilliseconds = delayValueUnit.toMillis(delayValue);
-            final DelayedGeoEvent delayedGeoEvent = new DelayedGeoEvent(geoEvent, delayMilliseconds);
+        String timeKey = delayedGeoEvent.getTimeKey();
+        String locationKey = delayedGeoEvent.getLocationKey();
+        String locationKeyValue = delayedGeoEvent.getLocationKeyValue();
 
-            geoEventQueue.put(delayedGeoEvent);
+        if (LOGGER.isTraceEnabled())
+        {
+          LOGGER.trace("Allow Duplicates is {2} Use TRACK_ID is {3}. Existing time key {0} = {1} and existing location key {4} ( {6} ) = {5} (non-null value for either means we've seen this point before)", timeKey, this.geoEventTimeKeySet.get(timeKey), allowDuplicates, useTrackID, locationKey, this.geoEventLocationKeySet.get(locationKey), locationKeyValue);
+        }
 
-            if(LOGGER.isDebugEnabled()) {
-                LOGGER.debug(String.format(
-                    "Added GeoEvent to Delay Queue: %s | delay: %d ms | queue size: %d",
-                    geoEvent.getGuid(),
-                    delayMilliseconds,
-                    this.geoEventQueue.size()));
+        if (allowDuplicates || ((this.geoEventTimeKeySet.put(timeKey, timeKey) == null) && (locationKey == null || this.geoEventLocationKeySet.put(locationKey, locationKeyValue) != locationKeyValue)))
+        {
+          this.geoEventQueue.put(delayedGeoEvent);
+          if (LOGGER.isDebugEnabled())
+            LOGGER.debug("Added GeoEvent with key {3} to Delay Queue with delay {1} ms and queue size {2}: {0}", geoEvent, delayMilliseconds, this.geoEventQueue.size(), delayedGeoEvent.getTimeKey());
+        }
+        else if (LOGGER.isDebugEnabled())
+        {
+          LOGGER.debug("Discarding duplicate GeoEvent with key {1}: {0}", geoEvent, delayedGeoEvent.getTimeKey());
+        }
             }
 
         }
@@ -76,145 +132,246 @@ public class DelayProcessor extends GeoEventProcessorBase
 
 
     @Override
-    public void onServiceStart() {
+  public void onServiceStart()
+  {
         super.onServiceStart();
+    LOGGER.trace("Enter OnServiceStart() of delay processor.");
 
-        try {
-            if (eventLoop != null) {
+    try
+    {
+      if (executorService == null || executorService.isShutdown() || executorService.isTerminated())
+      {
+        executorService = Executors.newSingleThreadExecutor();
+      }
+      if (eventLoop != null)
+      {
                 this.eventLoop.cancel(true);
+        LOGGER.trace("Previous Event Loop Canceled");
             }
             this.eventLoop = executorService.submit(constructEventLoop(this.geoEventQueue));
+      LOGGER.trace("Event Loop Started");
         }
-        catch(Exception ex) {
-            LOGGER.error(ex.getMessage());
+    catch (Exception ex)
+    {
+      LOGGER.error("Failed to start processor.", ex);
         }
+    LOGGER.trace("Exit OnServiceStart() of delay processor.");
     }
 
     @Override
-    public void onServiceStop() {
-        try {
-            if (eventLoop != null) {
+  public void onServiceStop()
+  {
+    LOGGER.trace("Enter OnServiceStop() of delay processor.");
+    try
+    {
+      if (eventLoop != null)
+      {
                 this.eventLoop.cancel(true);
             }
 
             this.geoEventQueue.clear(); // TODO: Make this configurable
+      LOGGER.debug("Cleared GeoEvent Queue");
         }
-        catch(Exception ex) {
-            LOGGER.error(ex.getMessage());
+    catch (Exception ex)
+    {
+      LOGGER.error("Failed to stop processor.", ex);
         }
         super.onServiceStop();
+    LOGGER.trace("Exit OnServiceStop() of delay processor.");
     }
 
-    protected Runnable constructEventLoop(final BlockingQueue<DelayedGeoEvent> inboundQueue) {
-        return () -> {
-            try {
+  protected Runnable constructEventLoop(final BlockingQueue<DelayedGeoEvent> inboundQueue)
+  {
+    LOGGER.trace("Enter constructEventLoop() of delay processor.");
+    return () ->
+      {
+        try
+        {
                 while (!Thread.currentThread().isInterrupted())
                 {
-                    final GeoEvent geoEvent = inboundQueue.take().getGeoEvent();
+            if (LOGGER.isTraceEnabled())
+            {
+              final DelayedGeoEvent peek = inboundQueue.peek();
+              if (peek != null)
+              {
+                LOGGER.trace("Time to next event {0} ms: {1}", peek.getTimeKey(), peek.getDelay(TimeUnit.MILLISECONDS));
+              }
+            }
 
-                    if(LOGGER.isDebugEnabled()) {
-                        final DelayedGeoEvent peek = this.geoEventQueue.peek();
-                        LOGGER.debug(String.format(
-                            "Processing Delayed GeoEvent: %s | queue size: %d | time to next event: %d ms",
-                            geoEvent.getGuid(),
-                            this.geoEventQueue.size(),
-                            peek == null ? 0 : peek.getDelay(TimeUnit.MILLISECONDS)));
+            final DelayedGeoEvent take = inboundQueue.take();
+            final GeoEvent geoEvent = take.getGeoEvent();
+
+            if (LOGGER.isTraceEnabled())
+            {
+              final DelayedGeoEvent peek = inboundQueue.peek();
+              LOGGER.trace("Sending Delayed GeoEvent with key {3} from queue with size {1}. Time to next event {2} ms: {0}", geoEvent, inboundQueue.size(), peek == null ? 0 : peek.getDelay(TimeUnit.MILLISECONDS), take.getTimeKey());
                     }
 
-                    try {
+            try
+            {
                         send(geoEvent);
-                    } catch (MessagingException e) {
-                        LOGGER.error(e.getMessage());
+            }
+            catch (MessagingException e)
+            {
+              LOGGER.error("Error sending geoevent: {0}", e, geoEvent);
+            }
                     }
                 }
+        catch (InterruptedException ie)
+        {
+          // Not usually an error, this is expected to happen
+          LOGGER.trace("Event consumer loop has stopped.");
             }
-            catch(InterruptedException ie) {
-                LOGGER.info("Thread interrupted:" + ie.getMessage());
+        catch (Exception e)
+        {
+          // This is unexpected
+          LOGGER.trace("Event consumer loop has stopped due to unknown error:", e);
             }
         };
     }
 
+  @Override
+  public void afterPropertiesSet()
+  {
+    LOGGER.trace("Enter afterPropertiesSet() of delay processor.");
+    try
+    {
+      delayValue = Long.parseLong(this.properties.get(DELAY_VALUE).getValueAsString());
 
-    @Override
-    public void afterPropertiesSet() {
-        try {
-            this.delayValue = Long.parseLong(
-                this.properties.get(DelayProcessorDefinition.DELAY_VALUE).getValueAsString());
+      delayValueUnit = TimeUnit.valueOf(this.properties.get(DELAY_VALUE_UNITS).getValueAsString());
 
-            this.delayValueUnit = TimeUnit.valueOf(
-                this.properties.get(DelayProcessorDefinition.DELAY_VALUE_UNITS).getValueAsString());
+      delayField = this.properties.get(DELAY_FIELD).getValueAsString();
+
+      enforceDelayThreshold = Boolean.parseBoolean(this.properties.get(ENFORCE_DELAY_THRESHOLD).getValueAsString());
+
+      allowDuplicates = Boolean.parseBoolean(this.properties.get(ALLOW_DUPLICATES).getValueAsString());
+
+      useTrackID = Boolean.parseBoolean(this.properties.get(USE_TRACK_ID).getValueAsString());
+
+      useLocation = Boolean.parseBoolean(this.properties.get(USE_LOCATION).getValueAsString());
+
+      Property clearCacheProperty = this.properties.get(CLEAR_CACHE);
+      boolean clearCache = Boolean.parseBoolean(clearCacheProperty.getValueAsString());
+
+      if (LOGGER.isTraceEnabled())
+      {
+        LOGGER.trace("Delay Value: {0} {1}", delayValue, delayValueUnit);
+        LOGGER.trace("Delay Field: {0}", delayField);
+        LOGGER.trace("Enforce Delay Threshold: {0}", enforceDelayThreshold);
+        LOGGER.trace("Allow Duplicates: {0}", allowDuplicates);
+        LOGGER.trace("Use TRACK_ID: {0}", useTrackID);
+        LOGGER.trace("Use Location: {0}", useLocation);
+        LOGGER.trace("Clear Cache: {0}", clearCache);
         }
-        catch(Exception ex) {
-            LOGGER.error(ex.getMessage());
         }
-        super.afterPropertiesSet();
+    catch (Exception ex)
+    {
+      LOGGER.error("Failed to get processor properties.", ex);
+    }
+    delayMilliseconds = delayValueUnit.toMillis(delayValue);
     }
 
     @Override
-    public void send(GeoEvent geoEvent) throws MessagingException {
+  public void send(GeoEvent geoEvent) throws MessagingException
+  {
+    LOGGER.trace("Enter send() of delay processor.");
         if (geoEventProducer != null && geoEvent != null)
         {
             geoEvent.setProperty(GeoEventPropertyName.TYPE, "event");
             geoEvent.setProperty(GeoEventPropertyName.OWNER_ID, getId());
-            geoEvent.setProperty(GeoEventPropertyName.OWNER_URI,definition.getUri());
+      geoEvent.setProperty(GeoEventPropertyName.OWNER_URI, definition.getUri());
             geoEventProducer.send(geoEvent);
+      LOGGER.debug("Sent GeoEvent to consumers: {0}", geoEvent);
         }
     }
 
-    public void setMessaging(Messaging messaging)
-    {
-        this.messaging = messaging;
+  // public void setMessaging(Messaging messaging)
+  // {
+  // LOGGER.trace("Enter setMessaging() of delay processor.");
+  // this.messaging = messaging;
+  // }
+
+    @Override
+  public String getStatusDetails()
+  {
+    LOGGER.trace("Enter getStatusDetails() of delay processor.");
+    return (geoEventProducer != null) ? geoEventProducer.getStatusDetails() : "";
     }
 
     @Override
-    public String getStatusDetails() {
-        return (geoEventProducer != null)
-            ? geoEventProducer.getStatusDetails()
-            : "";
-    }
-
-    @Override
-    public boolean isGeoEventMutator() {
+  public boolean isGeoEventMutator()
+  {
+    LOGGER.trace("Enter isGeoEventMutator() of delay processor.");
         return true;
     }
 
     @Override
-    public EventDestination getEventDestination() {
-        return (geoEventProducer != null)
-            ? geoEventProducer.getEventDestination()
-            : null;
+  public EventDestination getEventDestination()
+  {
+    LOGGER.trace("Enter getEventDestination() of delay processor.");
+    return (geoEventProducer != null) ? geoEventProducer.getEventDestination() : null;
     }
 
     @Override
-    public List<EventDestination> getEventDestinations() {
-        return (geoEventProducer != null)
-            ? Collections.singletonList(geoEventProducer.getEventDestination())
-            : new ArrayList<>();
+  public List<EventDestination> getEventDestinations()
+  {
+    LOGGER.trace("Enter getEventDestinations() of delay processor.");
+    return (geoEventProducer != null) ? Collections.singletonList(geoEventProducer.getEventDestination()) : new ArrayList<>();
     }
 
     @Override
-    public void disconnect() {
+  public void disconnect()
+  {
+    LOGGER.trace("Enter disconnect() of delay processor.");
         if (geoEventProducer != null)
             geoEventProducer.disconnect();
     }
 
     @Override
-    public boolean isConnected() {
+  public boolean isConnected()
+  {
+    LOGGER.trace("Enter isConnected() of delay processor.");
         return (geoEventProducer != null) && geoEventProducer.isConnected();
     }
 
     @Override
-    public void setup() throws MessagingException {
+  public void setup() throws MessagingException
+  {
         ;
     }
 
     @Override
-    public void init() throws MessagingException {
+  public void init() throws MessagingException
+  {
         ;
     }
 
     @Override
-    public void update(Observable o, Object arg) {
+  public void update(Observable o, Object arg)
+  {
         ;
     }
+
+  @Override
+  public void validate() throws ValidationException
+  {
+    LOGGER.trace("Enter validate() of delay processor.");
+    Property clearCacheProperty = this.properties.get(CLEAR_CACHE);
+    boolean clearCache = Boolean.parseBoolean(clearCacheProperty.getValueAsString());
+
+    if (clearCache)
+    {
+      geoEventTimeKeySet.clear();
+      geoEventLocationKeySet.clear();
+      LOGGER.debug("Clear cache requested, cleared key caches.");
+    }
+    getProperty(CLEAR_CACHE).setValue(false);
+
+    clearCacheProperty = this.properties.get(CLEAR_CACHE);
+    clearCache = Boolean.parseBoolean(clearCacheProperty.getValueAsString());
+
+    LOGGER.trace("Clear Cache: {0}", clearCache);
+
+    super.validate();
+  }
 }

--- a/src/main/java/com/esri/geoevent/processor/delay/DelayProcessorDefinition.java
+++ b/src/main/java/com/esri/geoevent/processor/delay/DelayProcessorDefinition.java
@@ -1,67 +1,102 @@
 package com.esri.geoevent.processor.delay;
 
-import com.esri.ges.core.property.LabeledValue;
-import com.esri.ges.core.property.PropertyDefinition;
-import com.esri.ges.core.property.PropertyException;
-import com.esri.ges.core.property.PropertyType;
-import com.esri.ges.processor.GeoEventProcessorDefinitionBase;
-
 import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.TimeUnit;
 
-public class DelayProcessorDefinition extends GeoEventProcessorDefinitionBase
-{
-    public static final String DELAY_VALUE = "delayValue";
-    public static final String DELAY_VALUE_UNITS = "delayValueUnits";
+import com.esri.ges.core.property.LabeledValue;
+import com.esri.ges.core.property.PropertyDefinition;
+import com.esri.ges.core.property.PropertyType;
+import com.esri.ges.framework.i18n.BundleLogger;
+import com.esri.ges.framework.i18n.BundleLoggerFactory;
+import com.esri.ges.processor.GeoEventProcessorDefinitionBase;
 
-    public DelayProcessorDefinition() {
+public class DelayProcessorDefinition extends GeoEventProcessorDefinitionBase implements DelayProperties
+{
+  private static final BundleLogger LOGGER                     = BundleLoggerFactory.getLogger(DelayProcessorDefinition.class);
+
+  // private static final String PROCESSOR_DOMAIN = STRINGS_PATH + "PROCESSOR_DOMAIN}";
+  // private static final String PROCESSOR_NAME = STRINGS_PATH + "PROCESSOR_NAME}";
+  private static final String       PROCESSOR_LABEL            = STRINGS_PATH + "PROCESSOR_LABEL}";
+  private static final String       PROCESSOR_DESC             = STRINGS_PATH + "PROCESSOR_DESC}";
+
+  private static final String       CLEAR_CACHE_DESC           = STRINGS_PATH + "CLEAR_CACHE_DESC}";
+  private static final String       CLEAR_CACHE_LABEL          = STRINGS_PATH + "CLEAR_CACHE_LABEL}";
+  private static final String       USE_LOCATION_DESC          = STRINGS_PATH + "USE_LOCATION_DESC}";
+  private static final String       USE_LOCATION_LABEL         = STRINGS_PATH + "USE_LOCATION_LABEL}";
+  private static final String       USE_TRACKID_DESC           = STRINGS_PATH + "USE_TRACKID_DESC}";
+  private static final String       USE_TRACKID_LABEL          = STRINGS_PATH + "USE_TRACKID_LABEL}";
+  private static final String       ALLOW_DUPLICATES_DESC      = STRINGS_PATH + "ALLOW_DUPLICATES_DESC}";
+  private static final String       ALLOW_DUPLICATES_LABEL     = STRINGS_PATH + "ALLOW_DUPLICATES_LABEL}";
+  private static final String       ENFORCE_DELAY_THRESH_DESC  = STRINGS_PATH + "ENFORCE_DELAY_THRESH_DESC}";
+  private static final String       ENFORCE_DELAY_THRESH_LABEL = STRINGS_PATH + "ENFORCE_DELAY_THRESH_LABEL}";
+  private static final String       DELAY_TIME_FIELD_DESC      = STRINGS_PATH + "DELAY_TIME_FIELD_DESC}";
+  private static final String       DELAY_TIME_FIELD_LABEL     = STRINGS_PATH + "DELAY_TIME_FIELD_LABEL}";
+  private static final String       DELAY_TIME_UNIT_DESC       = STRINGS_PATH + "DELAY_TIME_UNIT_DESC}";
+  private static final String       DELAY_TIME_UNIT_LABEL      = STRINGS_PATH + "DELAY_TIME_UNIT_LABEL}";
+  private static final String       DELAY_TIME_DESC            = STRINGS_PATH + "DELAY_TIME_DESC}";
+  private static final String       DELAY_TIME_LABEL           = STRINGS_PATH + "DELAY_TIME_LABEL}";
+
+  public DelayProcessorDefinition()
+  {
+    LOGGER.info("Creating definition for delay processor");
 
         final List<LabeledValue> allowedTimeUnits = new ArrayList<>();
-        for(TimeUnit value: TimeUnit.values()) {
+    for (TimeUnit value : TimeUnit.values())
+    {
             allowedTimeUnits.add(new LabeledValue(value.name(), value.name()));
         }
 
-        try {
-            propertyDefinitions.put(DELAY_VALUE,
-                new PropertyDefinition(DELAY_VALUE,
-                    PropertyType.Long,
-                    "0",
-                    "Delay Time",
-                    "Specify a delay value. GeoEvents will be delayed by this value before they are further processed.",
-                    true,
-                    false));
+    final List<LabeledValue> allowedTimeFields = new ArrayList<>();
+    allowedTimeFields.add(new LabeledValue(TIME_START, TIME_START));
+    allowedTimeFields.add(new LabeledValue(TIME_END, TIME_END));
+    allowedTimeFields.add(new LabeledValue(RECEIVED_TIME, RECEIVED_TIME));
 
-            propertyDefinitions.put(DELAY_VALUE_UNITS,
-                new PropertyDefinition(DELAY_VALUE_UNITS,
-                    PropertyType.String,
-                    TimeUnit.SECONDS.name(),
-                    "Delay Time Unit",
-                    "Choose the time unit for the delay value",
-                    true,
-                    false,
-                    allowedTimeUnits));
+    try
+    {
+      propertyDefinitions.put(DELAY_VALUE, new PropertyDefinition(DELAY_VALUE, PropertyType.Long, "0", DELAY_TIME_LABEL, DELAY_TIME_DESC, true, false));
 
+      propertyDefinitions.put(DELAY_VALUE_UNITS, new PropertyDefinition(DELAY_VALUE_UNITS, PropertyType.String, TimeUnit.SECONDS.name(), DELAY_TIME_UNIT_LABEL, DELAY_TIME_UNIT_DESC, true, false, allowedTimeUnits));
 
-        } catch (PropertyException e) {
-            e.printStackTrace();
+      propertyDefinitions.put(DELAY_FIELD, new PropertyDefinition(DELAY_FIELD, PropertyType.String, RECEIVED_TIME, DELAY_TIME_FIELD_LABEL, DELAY_TIME_FIELD_DESC, true, false, allowedTimeFields));
+
+      propertyDefinitions.put(ENFORCE_DELAY_THRESHOLD, new PropertyDefinition(ENFORCE_DELAY_THRESHOLD, PropertyType.Boolean, false, ENFORCE_DELAY_THRESH_LABEL, ENFORCE_DELAY_THRESH_DESC, true, false));
+
+      propertyDefinitions.put(ALLOW_DUPLICATES, new PropertyDefinition(ALLOW_DUPLICATES, PropertyType.Boolean, true, ALLOW_DUPLICATES_LABEL, ALLOW_DUPLICATES_DESC, true, false));
+
+      propertyDefinitions.put(USE_TRACK_ID, new PropertyDefinition(USE_TRACK_ID, PropertyType.Boolean, true, USE_TRACKID_LABEL, USE_TRACKID_DESC, ALLOW_DUPLICATES + "=false", true, false));
+
+      propertyDefinitions.put(USE_LOCATION, new PropertyDefinition(USE_LOCATION, PropertyType.Boolean, false, USE_LOCATION_LABEL, USE_LOCATION_DESC, ALLOW_DUPLICATES + "=false", true, false));
+
+      propertyDefinitions.put(CLEAR_CACHE, new PropertyDefinition(CLEAR_CACHE, PropertyType.Boolean, false, CLEAR_CACHE_LABEL, CLEAR_CACHE_DESC, true, false));
+    }
+    catch (Exception e)
+    {
+      LOGGER.warn("Failed to construct definition.", e);
         }
     }
 
+  // @Override
+  // public String getName()
+  // {
+  // return PROCESSOR_NAME;
+  // }
+  //
+  // @Override
+  // public String getDomain()
+  // {
+  // return PROCESSOR_DOMAIN;
+  // }
+
     @Override
-    public String getName()
+  public String getDescription()
     {
-        return "Delay Processor";
+    return PROCESSOR_DESC;
     }
 
     @Override
-    public String getDomain()
+  public String getLabel()
     {
-        return "com.esri.geoevent.processor";
-    }
-
-    @Override
-    public String getDescription() {
-        return "Delays the processing of events by a specified amount of time. All delayed events are held in a queue in memory.";
+    return PROCESSOR_LABEL;
     }
 }

--- a/src/main/java/com/esri/geoevent/processor/delay/DelayProcessorService.java
+++ b/src/main/java/com/esri/geoevent/processor/delay/DelayProcessorService.java
@@ -1,27 +1,34 @@
 package com.esri.geoevent.processor.delay;
 
 import com.esri.ges.core.component.ComponentException;
+import com.esri.ges.framework.i18n.BundleLogger;
+import com.esri.ges.framework.i18n.BundleLoggerFactory;
 import com.esri.ges.messaging.Messaging;
 import com.esri.ges.processor.GeoEventProcessor;
 import com.esri.ges.processor.GeoEventProcessorServiceBase;
 
 public class DelayProcessorService extends GeoEventProcessorServiceBase
 {
+  private static final BundleLogger LOGGER = BundleLoggerFactory.getLogger(DelayProcessorService.class);
+
     private Messaging messaging;
 
     public DelayProcessorService()
     {
+    LOGGER.trace("Creating Delay Processor Service");
         this.definition = new DelayProcessorDefinition();
+    LOGGER.trace("Set Delay Processor definition on service");
     }
 
     @Override
-    public GeoEventProcessor create() throws ComponentException {
-        DelayProcessor delayProcessor = new DelayProcessor(definition);
-        delayProcessor.setMessaging(messaging);
+  public GeoEventProcessor create() throws ComponentException
+  {
+    DelayProcessor delayProcessor = new DelayProcessor(definition, messaging);
         return delayProcessor;
     }
 
-    public void setMessaging(Messaging messaging) {
+  public void setMessaging(Messaging messaging)
+  {
         this.messaging = messaging;
     }
 }

--- a/src/main/java/com/esri/geoevent/processor/delay/DelayProperties.java
+++ b/src/main/java/com/esri/geoevent/processor/delay/DelayProperties.java
@@ -1,0 +1,18 @@
+package com.esri.geoevent.processor.delay;
+
+public interface DelayProperties
+{
+  static final String STRINGS_PATH            = "${com.esri.geoevent.processor.delay-processor.";
+
+  static final String DELAY_VALUE             = "delayValue";
+  static final String DELAY_VALUE_UNITS       = "delayValueUnits";
+  static final String DELAY_FIELD             = "delayField";
+  static final String ENFORCE_DELAY_THRESHOLD = "enforceDelayThreshold";
+  static final String ALLOW_DUPLICATES        = "allowDuplicates";
+  static final String USE_LOCATION            = "useLocation";
+  static final String USE_TRACK_ID            = "useTrackID";
+  static final String CLEAR_CACHE             = "clearCache";
+  static final String TIME_START              = "TIME_START";
+  static final String TIME_END                = "TIME_END";
+  static final String RECEIVED_TIME           = "RECEIVED_TIME";
+}

--- a/src/main/java/com/esri/geoevent/processor/delay/DelayedGeoEvent.java
+++ b/src/main/java/com/esri/geoevent/processor/delay/DelayedGeoEvent.java
@@ -1,21 +1,85 @@
 package com.esri.geoevent.processor.delay;
 
-import com.esri.ges.core.geoevent.GeoEvent;
-
 import java.util.concurrent.Delayed;
 import java.util.concurrent.TimeUnit;
 
-public class DelayedGeoEvent implements Delayed {
+import com.esri.core.geometry.Geometry.Type;
+import com.esri.core.geometry.Point;
+import com.esri.ges.core.geoevent.GeoEvent;
+import com.esri.ges.framework.i18n.BundleLogger;
+import com.esri.ges.framework.i18n.BundleLoggerFactory;
+
+public class DelayedGeoEvent implements Delayed
+{
+  private static final BundleLogger LOGGER = BundleLoggerFactory.getLogger(DelayProcessor.class);
+
     private final GeoEvent geoEvent;
     private final long time;
+  private final boolean             useTrackID;
+  private final String              timeKey;
+  private final String              locationKey;
+  private final String              locationKeyValue;
 
-    public DelayedGeoEvent(GeoEvent geoEvent, long delayTimeMs) {
+  public DelayedGeoEvent(GeoEvent geoEvent, long delayTimeMs, String delayTimeField, boolean useTrackID)
+  {
         this.geoEvent = geoEvent;
-        this.time = geoEvent.getReceivedTime().getTime() + delayTimeMs;
+    this.useTrackID = useTrackID;
+    String definitionGuid = geoEvent.getGeoEventDefinition().getGuid();
+    long keyTime = geoEvent.getReceivedTime().getTime();
+
+    if (DelayProperties.TIME_END.equals(delayTimeField))
+      keyTime = geoEvent.getEndTime().getTime();
+    else if (DelayProperties.TIME_START.equals(delayTimeField))
+      keyTime = geoEvent.getStartTime().getTime();
+
+    this.time = keyTime + delayTimeMs;
+
+    // timeKey starts with time to preserve queue time order
+    if (useTrackID)
+      this.timeKey = keyTime + "_" + definitionGuid + "_" + geoEvent.getTrackId();
+    else
+      this.timeKey = keyTime + "_" + definitionGuid;
+
+    if (geoEvent.getGeometry() != null && geoEvent.getGeometry().getGeometry() != null && geoEvent.getGeometry().getGeometry().getType().equals(Type.Point))
+    {
+      // only point geometries are supported
+      Point geometry = (Point) geoEvent.getGeometry().getGeometry();
+      this.locationKey = definitionGuid + "_" + geoEvent.getTrackId();
+      this.locationKeyValue = geometry.getX() + "_" + geometry.getY() + "_" + definitionGuid + "_" + geoEvent.getTrackId();
+
+      // else
+      // {
+      // Point point = ((Polygon) geometry.getBoundary()).getPoint(0);
+      // this.locationKey = point.getX() + "_" + point.getY() + "_" + geoEvent.getTrackId();
+      // }
+    }
+    else
+    {
+      this.locationKey = null;
+      this.locationKeyValue = null;
+    }
+
+    LOGGER.trace("Created delayed event with timeKey {0} using {1} field time {2}. Location key is {5}. Delay time is {3} ms so release time is {4}.", timeKey, delayTimeField, keyTime, delayTimeMs, time, locationKey);
+  }
+
+  public String getTimeKey()
+  {
+    return this.timeKey;
+  }
+
+  public String getLocationKey()
+  {
+    return this.locationKey;
+  }
+
+  public String getLocationKeyValue()
+  {
+    return this.locationKeyValue;
     }
 
     @Override
-    public long getDelay(TimeUnit unit) {
+  public long getDelay(TimeUnit unit)
+  {
         long diff = this.time - System.currentTimeMillis();
         return unit.convert(diff, TimeUnit.MILLISECONDS);
     }
@@ -23,10 +87,17 @@ public class DelayedGeoEvent implements Delayed {
     @Override
     public int compareTo(Delayed obj)
     {
-        return Long.compare(this.time, ((DelayedGeoEvent)obj).time);
+    int result = Long.compare(this.time, ((DelayedGeoEvent) obj).time);
+    if (useTrackID)
+    {
+      result = this.timeKey.compareTo(((DelayedGeoEvent) obj).timeKey);
     }
 
-    public GeoEvent getGeoEvent() {
+    return result;
+  }
+
+  public GeoEvent getGeoEvent()
+  {
         return this.geoEvent;
     }
 }

--- a/src/main/resources/OSGI-INF/blueprint/config.xml
+++ b/src/main/resources/OSGI-INF/blueprint/config.xml
@@ -1,5 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <blueprint xmlns="http://www.osgi.org/xmlns/blueprint/v1.0.0">
+
+	<reference id="messagingService"
+		interface="com.esri.ges.messaging.Messaging" />
+
 	<bean id="delayProcessorServiceBean"
 		  class="com.esri.geoevent.processor.delay.DelayProcessorService"
 		  activation="eager">
@@ -7,12 +11,7 @@
 		<property name="messaging" ref="messagingService" />
 	</bean>
 
-	<reference id="messagingService"
-			   interface="com.esri.ges.messaging.Messaging"/>
-
 	<service id="delayProcessorService"
 			 ref="delayProcessorServiceBean"
-			 interface="com.esri.ges.processor.GeoEventProcessorService"
-	/>
-
+		interface="com.esri.ges.processor.GeoEventProcessorService" />
 </blueprint>


### PR DESCRIPTION
Updated to include discarding events older than the delay threshold.

Other changes added up to now include, using track id, time and location to discard duplicate events.